### PR TITLE
fix: don't override default generic types in useObservableQuery

### DIFF
--- a/src/react-hooks/useObservableQuery.ts
+++ b/src/react-hooks/useObservableQuery.ts
@@ -75,7 +75,14 @@ const getHasError = <TData, TError, TQueryFnData, TQueryData, TQueryKey extends 
     );
 };
 
-export function useObservableQuery<TQueryFnData, TError, TData, TQueryData, TQueryKey extends QueryKey, TContext>(
+export function useObservableQuery<
+    TQueryFnData,
+    TError,
+    TData = TQueryFnData,
+    TQueryData = TQueryFnData,
+    TQueryKey extends QueryKey = QueryKey,
+    TContext = unknown,
+>(
     options: UseBaseQueryOptions<TQueryFnData, TError, TData, TQueryData, TQueryKey> & { queryClient?: QueryClient },
     mutationOptions?: UseMutationOptions<TData, TError, void, TContext>,
 ): ObservableObject<UseBaseQueryResult<TData, TError>> {


### PR DESCRIPTION
Issue is that generic args are inferred and all generic arguments are passed to `UseBaseQueryOptions` explicitly.

```typescript
export interface UseBaseQueryOptions<
  TQueryFnData = unknown,
  TError = unknown,
  TData = TQueryFnData,
  TQueryData = TQueryFnData,
  TQueryKey extends QueryKey = QueryKey
> extends ...
```
Causing the defaults to be overidden with `unknown`

In a simple case like:

```typescript
        const query$ = useObservableQuery({
            queryKey: ['test'],
            queryFn: () => Promise.resolve({ a: 1, b: 2 }),
        });
```

it would not be able to infer TData, therefore the resulting type will be: `ObservableObject<UseBaseQueryResult<unknown, unknown>`

